### PR TITLE
Update package.json by adding gatsby-plugin keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "keywords": [
     "gatsby",
+    "gatsby-plugin",
     "ipynb",
     "jupyter",
     "plugin",


### PR DESCRIPTION
## Changes
* Added `gatsby-plugin` keyword to package.json
## Description
Hello. I found that the `package.json` file does not contain the keyword `gatsby-plugin`. This change will [submit the plugin to the Gatsby Plugin Library](https://www.gatsbyjs.org/contributing/submit-to-plugin-library/). You can also go to gatsbyjs/gatsby#14013 for more detailed information. Thanks.